### PR TITLE
ci: improve GitHub Action step name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: glith deploy
+      - name: Deploy to Glitch
         if: github.ref == 'refs/heads/master'
         run: |
           if [[ ! -z "$GLITCH_PROJECT_ID" ]] && [[ ! -z "$GLITCH_TOKEN" ]]


### PR DESCRIPTION
## Changes:

- Change GitHub Action step name from `glith deploy` to `Deploy to Glitch`

## Context:

I think this change makes it clearer what this step is doing.

