### PR TITLE
chore: fix typo in comment

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,7 @@ export function mocked<T>(module: T): jest.Mocked<T> {
 }
 
 /**
- * Simply wrapper to create partial mocks.
+ * Simple wrapper to create partial mocks.
  * @param obj Object to cast to final type
  */
 export function partial<T>(obj?: Partial<T>): T {


### PR DESCRIPTION
## Change:

- `Simply wrapper` -> `Simple wrapper`

## Context:

Fix typo.